### PR TITLE
[optimize] global event name and the way of addEventListener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# 1.0.1
+生命周期，自定义事件均做调整，如果不更改，请不要升级到 `1.0.1`。
+* `bmRouter` 变更为 `eros`
+* 添加 `pushMessage`，可在页面中监听推送
+* 添加 `appActive`，可在页面中监听 app 切换到后台事件
+* 添加 `appDeactive`，可在页面中监听 app 切换至前台事件
+* `viewWillAppear` 变更为 `beforeAppear`，beforeBackAppear，通过打开类型来做区分
+* `viewDidAppear` 变更为 `appeared`，`backAppeared`，通过打开类型来做区分
+* `viewWillDisappear` 变更为 `beforeDisappear`
+* `viewDidDisappear` 变更为 `disappeared`
+
+# 1.0.0
+* 从模板中抽离 widget 完成

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ eros widget is the two encapsulation for eros module.
 $ npm i eros-widget -S
 ```
 2.init widget in appboard js bundle.(default: `config/index.js`)
-```
+``` js
 import widget from 'eros-Widget'
 
 const options = {}
@@ -76,26 +76,26 @@ routes: {
 #### `ajax.apis`: config you request path alias
 ```js
 apis: {
-	'COMMON.getInfo': '/test/info/'
+    'COMMON.getInfo': '/test/info/'
 }
 ```
  also you can config dynamic path.
-```
+```js
 apis: {
-	'COMMON.getInfo': '/test/info/{plaform}/{id}'
+    'COMMON.getInfo': '/test/info/{plaform}/{id}'
 }
 ```
 and we deliver them in $get/$post params option.
 ```js
 this.$get({
-	name: 'COMMON.getInfo',
-	params: {
-		platform: 'app',
-		id: 3
-	},
-	data: {
-		name: 'eros'
-	}
+    name: 'COMMON.getInfo',
+    params: {
+        platform: 'app',
+        id: 3
+    },
+    data: {
+        name: 'eros'
+    }
 })
 ```
 finally our request url become :
@@ -123,16 +123,16 @@ $ cd eros-demo/src/js
 
 3.clone eros-widget.git.
 ```
-git clone https://github.com/bmfe/eros-widget.git eros-widget
+$ git clone https://github.com/bmfe/eros-widget.git eros-widget
 ```
 
 4.add config `eros.dev.js` alias option.
-```
-	"ErosWidget": "js/eros-widget"
+```js
+"ErosWidget": "js/eros-widget"
 ```
 
 5.init widget in appboard js bundle.(default: `config/index.js`)
-```
+```js
 import ErosWidget from 'ErosWidget'
 
 const options = {}
@@ -141,3 +141,18 @@ new ErosWidget(options)
 ```
 
 > welcome your pull request! eros loves you.
+
+## Records
+# 1.0.1
+生命周期，自定义事件均做调整，如果不更改，请不要升级到 `1.0.1`。
+* `bmRouter` 变更为 `eros`
+* 添加 `pushMessage`，可在页面中监听推送
+* 添加 `appActive`，可在页面中监听 app 切换到后台事件
+* 添加 `appDeactive`，可在页面中监听 app 切换至前台事件
+* `viewWillAppear` 变更为 `beforeAppear`，beforeBackAppear，通过打开类型来做区分
+* `viewDidAppear` 变更为 `appeared`，`backAppeared`，通过打开类型来做区分
+* `viewWillDisappear` 变更为 `beforeDisappear`
+* `viewDidDisappear` 变更为 `disappeared`
+
+# 1.0.0
+* 从模板中抽离 widget 完成

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 
 // 配置方法
+import './src/mixins.js'
+
 import './src/font.js'
 // 弹窗
 import './src/notice.js'

--- a/src/events.js
+++ b/src/events.js
@@ -5,41 +5,41 @@
  * @Last modified time: 2017-04-10
  */
 
-import _isArray from 'lodash/isArray'
+// import _isArray from 'lodash/isArray'
 var event = weex.requireModule('bmEvents')
-var globalEvent = weex.requireModule('globalEvent')
+// var globalEvent = weex.requireModule('globalEvent')
 
 const GlobalEvent = Object.create(null)
-const GLOBALEVENT = Object.create(null)
+// const GLOBALEVENT = Object.create(null)
 
-// app 被放到后台 appWillResignActive
-globalEvent.addEventListener('appDeactive', function (options) {
-    _isArray(GLOBALEVENT['appDeactive']) && GLOBALEVENT['appDeactive'].map((item) => {
-        item(options)
-    })
-})
+// // app 被放到后台 appWillResignActive
+// globalEvent.addEventListener('appDeactive', function (options) {
+//     _isArray(GLOBALEVENT['appDeactive']) && GLOBALEVENT['appDeactive'].map((item) => {
+//         item(options)
+//     })
+// })
 
-// app 从后台唤起 appDidBecomeActive
-globalEvent.addEventListener('appActive', function (options) {
-    _isArray(GLOBALEVENT['appActive']) && GLOBALEVENT['appActive'].map((item) => {
-        item(options)
-    })
-})
+// // app 从后台唤起 appDidBecomeActive
+// globalEvent.addEventListener('appActive', function (options) {
+//     _isArray(GLOBALEVENT['appActive']) && GLOBALEVENT['appActive'].map((item) => {
+//         item(options)
+//     })
+// })
 
 GlobalEvent.install = (Vue, options) => {
-    Vue.mixin({
-        beforeCreate () {
-            if (this.$options.globalEvent) {
-                var ev = this.$options.globalEvent
-                for (var i in ev) {
-                    if (!GLOBALEVENT[i]) {
-                        GLOBALEVENT[i] = []
-                    }
-                    GLOBALEVENT[i].push(ev[i].bind(this))
-                }
-            }
-        }
-    })
+    // Vue.mixin({
+    //     beforeCreate () {
+    //         if (this.$options.globalEvent) {
+    //             var ev = this.$options.globalEvent
+    //             for (var i in ev) {
+    //                 if (!GLOBALEVENT[i]) {
+    //                     GLOBALEVENT[i] = []
+    //                 }
+    //                 GLOBALEVENT[i].push(ev[i].bind(this))
+    //             }
+    //         }
+    //     }
+    // })
     Vue.prototype.$event = event
 }
 

--- a/src/mixins.js
+++ b/src/mixins.js
@@ -1,0 +1,119 @@
+
+/**
+ * 消息推送
+ * options 客户端个推推送的所有消息
+ */
+
+import _isArray from 'lodash/isArray'
+
+const globalEvent = weex.requireModule('globalEvent')
+const storage = weex.requireModule('bmStorage')
+const router = weex.requireModule('bmRouter')
+const modal = weex.requireModule('bmModal')
+
+const Mixins = Object.create(null)
+const GLOBAL_EVENTS = Object.create(null)
+
+class EventsMaker {
+    constructor(events) {
+        events && events.length && events.map(event => {
+            this[`${event}Maker`]()
+        })
+    }
+    pushMessageMaker() {
+        globalEvent.addEventListener('pushMessage', (options) => {
+            _isArray(GLOBAL_EVENTS['pushMessage']) && GLOBAL_EVENTS['pushMessage'].map((item) => {
+                item(options)
+            })
+        })
+    }
+    beforeAppearMaker() {
+        globalEvent.addEventListener('viewWillAppear', (options) => {
+            if (options.type === 'open' || options.type === 'refresh') {
+                router.getParams((params) => {
+                    _isArray(GLOBAL_EVENTS['beforeAppear']) &&GLOBAL_EVENTS['beforeAppear'].map((item) => {
+                        item(params, options)
+                    })
+                })
+            } else if (options.type === 'back') {
+                storage.getData('router.backParams', ({ status, errorMsg, data }) => {
+                    const result = status === 0 ? JSON.parse(data) : ''
+                    _isArray(GLOBAL_EVENTS['beforeBackAppear']) &&GLOBAL_EVENTS['beforeBackAppear'].map((item) => {
+                        item(result, options)
+                    })
+                })
+            }
+        })
+    }
+    beforeBackAppearMaker() {
+       this.beforeAppearMaker()
+    }
+    appearedMaker() {
+        globalEvent.addEventListener('viewDidAppear', (options) => {
+            if (options.type === 'open' || options.type === 'refresh') {
+                router.getParams((params) => {
+                    _isArray(GLOBAL_EVENTS['appeared']) &&GLOBAL_EVENTS['appeared'].map((item) => {
+                        item(params, options)
+                    })
+                })
+            } else if (options.type === 'back') {
+                storage.getData('router.backParams', ({ status, errorMsg, data }) => {
+                    const result = status === 0 ? JSON.parse(data) : ''
+                    _isArray(GLOBAL_EVENTS['backAppeared']) &&GLOBAL_EVENTS['backAppeared'].map((item) => {
+                        item(result, options)
+                    })
+                    storage.deleteData('router.backParams')
+                })
+            }
+        })
+    }
+    backAppearedMaker() {
+        this.appearedMaker()
+    }
+    beforeDisappearMaker() {
+        globalEvent.addEventListener('viewWillDisappear', (options) => {
+            modal.hideLoading()
+            _isArray(GLOBAL_EVENTS['beforeDisappear']) && GLOBAL_EVENTS['beforeDisappear'].map((item) => {
+                item(options)
+            })
+        })
+    }
+    disappearedMaker() {
+        globalEvent.addEventListener('viewDidDisappear', (options) => {
+            _isArray(GLOBAL_EVENTS['disappeared']) &&GLOBAL_EVENTS['disappeared'].map((item) => {
+                item(options)
+            })
+        })
+    }
+    appDeactiveMaker() {
+        globalEvent.addEventListener('appDeactive', (options) => {
+            _isArray(GLOBAL_EVENTS['appDeactive']) && GLOBAL_EVENTS['appDeactive'].map((item) => {
+                item(options)
+            })
+        })
+    }
+    appActiveMaker() {
+        globalEvent.addEventListener('appActive', (options) => {
+            _isArray(GLOBAL_EVENTS['appActive']) && GLOBAL_EVENTS['appActive'].map((item) => {
+                item(options)
+            })
+        })
+    }
+}
+
+Mixins.install = (Vue, options) => {
+    Vue.mixin({
+        beforeCreate () {
+            if (!this.$options.eros) return
+            const erosEvents = this.$options.eros
+            const erosEventsMap = Object.keys(this.$options.eros)
+            new EventsMaker(erosEventsMap)
+            erosEventsMap.map(event => {
+                if (!GLOBAL_EVENTS[event]) GLOBAL_EVENTS[event] = []
+                GLOBAL_EVENTS[event].push(erosEvents[event].bind(this))
+            })
+        }
+    })
+}
+
+Vue.use(Mixins)

--- a/src/router.js
+++ b/src/router.js
@@ -17,68 +17,68 @@ import _isNumber from 'lodash/isNumber'
 // 客户端默认打开页面的动画
 export const DEFAULT_ANIMATETYPE = 'PUSH'
 
-var RouterCycle = {
-    // 页面将要出现
-    viewWillAppear: [],
-    // 页面已经出现
-    viewDidAppear: [],
-    // 页面被拿出栈时即将展示
-    viewWillBackAppear: [],
-    // 页面被拿出栈时已经展示
-    viewDidBackAppear: [],
-    // 页面将要放在栈中
-    viewWillDisappear: [],
-    // 页面已经放在栈中
-    viewDidDisappear: []
-}
+// var RouterCycle = {
+//     // 页面将要出现
+//     viewWillAppear: [],
+//     // 页面已经出现
+//     viewDidAppear: [],
+//     // 页面被拿出栈时即将展示
+//     viewWillBackAppear: [],
+//     // 页面被拿出栈时已经展示
+//     viewDidBackAppear: [],
+//     // 页面将要放在栈中
+//     viewWillDisappear: [],
+//     // 页面已经放在栈中
+//     viewDidDisappear: []
+// }
 
-globalEvent.addEventListener('viewWillAppear', function (options) {
-    if (options.type === 'open' || options.type === 'refresh') {
-        router.getParams((params) => {
-            RouterCycle.viewWillAppear.map((item) => {
-                item(params, options)
-            })
-        })
-    } else if (options.type === 'back') {
-        storage.getData('router.backParams', ({ status, errorMsg, data }) => {
-            const result = status === 0 ? JSON.parse(data) : ''
-            RouterCycle.viewWillBackAppear.map((item) => {
-                item(result, options)
-            })
-        })
-    }
-})
+// globalEvent.addEventListener('viewWillAppear', function (options) {
+//     if (options.type === 'open' || options.type === 'refresh') {
+//         router.getParams((params) => {
+//             RouterCycle.viewWillAppear.map((item) => {
+//                 item(params, options)
+//             })
+//         })
+//     } else if (options.type === 'back') {
+//         storage.getData('router.backParams', ({ status, errorMsg, data }) => {
+//             const result = status === 0 ? JSON.parse(data) : ''
+//             RouterCycle.viewWillBackAppear.map((item) => {
+//                 item(result, options)
+//             })
+//         })
+//     }
+// })
 
-globalEvent.addEventListener('viewDidAppear', function (options) {
-    if (options.type === 'open' || options.type === 'refresh') {
-        router.getParams((params) => {
-            RouterCycle.viewDidAppear.map((item) => {
-                item(params, options)
-            })
-        })
-    } else if (options.type === 'back') {
-        storage.getData('router.backParams', ({ status, errorMsg, data }) => {
-            const result = status === 0 ? JSON.parse(data) : ''
-            RouterCycle.viewDidBackAppear.map((item) => {
-                item(result, options)
-            })
-            storage.deleteData('router.backParams')
-        })
-    }
-})
+// globalEvent.addEventListener('viewDidAppear', function (options) {
+//     if (options.type === 'open' || options.type === 'refresh') {
+//         router.getParams((params) => {
+//             RouterCycle.viewDidAppear.map((item) => {
+//                 item(params, options)
+//             })
+//         })
+//     } else if (options.type === 'back') {
+//         storage.getData('router.backParams', ({ status, errorMsg, data }) => {
+//             const result = status === 0 ? JSON.parse(data) : ''
+//             RouterCycle.viewDidBackAppear.map((item) => {
+//                 item(result, options)
+//             })
+//             storage.deleteData('router.backParams')
+//         })
+//     }
+// })
 
-globalEvent.addEventListener('viewWillDisappear', function (options) {
-    modal.hideLoading()
-    RouterCycle.viewWillDisappear.map((item) => {
-        item(options)
-    })
-})
+// globalEvent.addEventListener('viewWillDisappear', function (options) {
+//     modal.hideLoading()
+//     RouterCycle.viewWillDisappear.map((item) => {
+//         item(options)
+//     })
+// })
 
-globalEvent.addEventListener('viewDidDisappear', function (options) {
-    RouterCycle.viewDidDisappear.map((item) => {
-        item(options)
-    })
-})
+// globalEvent.addEventListener('viewDidDisappear', function (options) {
+//     RouterCycle.viewDidDisappear.map((item) => {
+//         item(options)
+//     })
+// })
 
 export default class Router {
     constructor ({ routes }) {
@@ -87,19 +87,19 @@ export default class Router {
     }
     install (Vue, options) {
         const self = this
-        Vue.mixin({
-            beforeCreate () {
-                if (this.$options.bmRouter) {
-                    var bmRouter = this.$options.bmRouter
-                    for (var i in bmRouter) {
-                        if (!RouterCycle[i]) {
-                            RouterCycle[i] = []
-                        }
-                        RouterCycle[i].push(bmRouter[i].bind(this))
-                    }
-                }
-            }
-        })
+        // Vue.mixin({
+        //     beforeCreate () {
+        //         if (this.$options.bmRouter) {
+        //             var bmRouter = this.$options.bmRouter
+        //             for (var i in bmRouter) {
+        //                 if (!RouterCycle[i]) {
+        //                     RouterCycle[i] = []
+        //                 }
+        //                 RouterCycle[i].push(bmRouter[i].bind(this))
+        //             }
+        //         }
+        //     }
+        // })
         Vue.prototype.$router = {
             open (options) {
                 options = options || {}


### PR DESCRIPTION
生命周期，自定义事件均做调整，如果不更改，请不要升级到 `1.0.1`。
* `bmRouter` 变更为 `eros`
* 添加 `pushMessage`，可在页面中监听推送
* 添加 `appActive`，可在页面中监听 app 切换到后台事件
* 添加 `appDeactive`，可在页面中监听 app 切换至前台事件
* `viewWillAppear` 变更为 `beforeAppear`，beforeBackAppear，通过打开类型来做区分
* `viewDidAppear` 变更为 `appeared`，`backAppeared`，通过打开类型来做区分
* `viewWillDisappear` 变更为 `beforeDisappear`
* `viewDidDisappear` 变更为 `disappeared`
